### PR TITLE
Fix Travis CI unable to find BuildTools version 23.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+sudo: false
 language: android
 android:
   components:
+    - platform-tools
+    - tools
     - build-tools-23.0.3
     - android-23
+    - extra-android-m2repository
+    - extra-google-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Related #197