### PR TITLE
Fix legacy behavior of adjustViewBounds attribute on Android 17 and below

### DIFF
--- a/app/src/main/java/com/mozilla/hackathon/kiboko/activities/ResultActivity.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/activities/ResultActivity.java
@@ -10,8 +10,7 @@ import android.widget.TextView;
 
 import com.mozilla.hackathon.kiboko.Analytics;
 import com.mozilla.hackathon.kiboko.R;
-
-import pl.droidsonroids.gif.GifImageView;
+import com.mozilla.hackathon.kiboko.widgets.AdjustableGifImageView;
 
 public class ResultActivity extends AppCompatActivity {
     private static int[] imageResources = new int[]{
@@ -40,7 +39,7 @@ public class ResultActivity extends AppCompatActivity {
 
         Analytics.add("Icon Quiz Finished", Integer.toString(score));
 
-        GifImageView gifImageView = (GifImageView) findViewById((R.id.result_image));
+        AdjustableGifImageView gifImageView = (AdjustableGifImageView) findViewById(R.id.result_image);
         int randomIndex = Double.valueOf(Math.random() * imageResources.length).intValue();
         gifImageView.setImageResource(imageResources[randomIndex]);
     }

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/fragments/ScreenSlidePageFragment.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/fragments/ScreenSlidePageFragment.java
@@ -14,13 +14,11 @@ import android.widget.TextView;
 import com.mozilla.hackathon.kiboko.R;
 import com.mozilla.hackathon.kiboko.settings.SettingsUtils;
 import com.mozilla.hackathon.kiboko.utils.Utils;
+import com.mozilla.hackathon.kiboko.widgets.AdjustableGifImageView;
 import com.mozilla.hackathon.kiboko.widgets.NotifyingScrollView;
 
 import org.sufficientlysecure.htmltextview.EmojiUtils;
 import org.sufficientlysecure.htmltextview.HtmlTextView;
-
-import pl.droidsonroids.gif.GifDrawable;
-import pl.droidsonroids.gif.GifImageView;
 
 import static com.mozilla.hackathon.kiboko.utils.LogUtils.makeLogTag;
 
@@ -40,7 +38,6 @@ public class ScreenSlidePageFragment extends Fragment {
     private float mActionBarHeight;
     private ActionBar mActionBar;
     public static NotifyingScrollView mScrollview;
-    private GifDrawable gifDrawable;
     /**
      * The fragment's page number, which is set to the argument value for {@link #ARG_PAGE}.
      */
@@ -97,9 +94,10 @@ public class ScreenSlidePageFragment extends Fragment {
         ((HtmlTextView) rootView.findViewById(R.id.step_description)).setFunMode(SettingsUtils.isFunModeEnabled(getContext()));
         ((HtmlTextView) rootView.findViewById(R.id.step_description)).setHtmlFromString(mPageDescription, new HtmlTextView.LocalImageGetter());
 
-        GifImageView gifImageView = (GifImageView) rootView.findViewById(R.id.step_image);
+        AdjustableGifImageView gifImageView = (AdjustableGifImageView) rootView.findViewById(R.id.step_image);
         gifImageView.setTag(mPageImage);
         gifImageView.setImageResource(Utils.getResId(getContext(), mPageImage));
+
         // Remove imageView from layout if gif isn't available
         if (Utils.getResId(getContext(), mPageImage) == R.drawable.blank) {
             gifImageView.setVisibility(View.GONE);

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/widgets/AdjustableGifImageView.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/widgets/AdjustableGifImageView.java
@@ -1,0 +1,92 @@
+package com.mozilla.hackathon.kiboko.widgets;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import pl.droidsonroids.gif.GifImageView;
+
+/**
+ * Patches legacy compatibility behaviour of the adjustViewBounds attribute on Android 17 and below.
+ *
+ * See Also:
+ *      https://developer.android.com/reference/android/widget/ImageView.html#setAdjustViewBounds(boolean)
+ *      https://github.com/nuuneoi/AdjustableImageView
+ */
+public class AdjustableGifImageView extends GifImageView {
+
+    private boolean mAdjustViewBounds;
+
+    public AdjustableGifImageView(Context context) {
+        super(context);
+    }
+
+    public AdjustableGifImageView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public AdjustableGifImageView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public AdjustableGifImageView(Context context, AttributeSet attrs, int defStyle, int defStyleRes) {
+        super(context, attrs, defStyle, defStyleRes);
+    }
+
+    @Override
+    public void setAdjustViewBounds(boolean adjustViewBounds) {
+        mAdjustViewBounds = adjustViewBounds;
+        super.setAdjustViewBounds(adjustViewBounds);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        Drawable mDrawable = getDrawable();
+        if (mDrawable == null) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            return;
+        }
+
+        if (mAdjustViewBounds) {
+            int mDrawableWidth = mDrawable.getIntrinsicWidth();
+            int mDrawableHeight = mDrawable.getIntrinsicHeight();
+            int heightSize = MeasureSpec.getSize(heightMeasureSpec);
+            int widthSize = MeasureSpec.getSize(widthMeasureSpec);
+            int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+            int widthMode = MeasureSpec.getMode(widthMeasureSpec);
+
+            if (heightMode == MeasureSpec.EXACTLY && widthMode != MeasureSpec.EXACTLY) {
+                int height = heightSize;
+                int width = height * mDrawableWidth / mDrawableHeight;
+                if (isInScrollingContainer())
+                    setMeasuredDimension(width, height);
+                else
+                    setMeasuredDimension(Math.min(width, widthSize), Math.min(height, heightSize));
+            } else if (widthMode == MeasureSpec.EXACTLY && heightMode != MeasureSpec.EXACTLY) {
+                int width = widthSize;
+                int height = width * mDrawableHeight / mDrawableWidth;
+                if (isInScrollingContainer())
+                    setMeasuredDimension(width, height);
+                else
+                    setMeasuredDimension(Math.min(width, widthSize), Math.min(height, heightSize));
+            } else {
+                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            }
+        } else {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        }
+    }
+
+    private boolean isInScrollingContainer() {
+        ViewParent p = getParent();
+        while (p != null && p instanceof ViewGroup) {
+            if (((ViewGroup) p).shouldDelayChildPressedState()) {
+                return true;
+            }
+            p = p.getParent();
+        }
+        return false;
+    }
+}

--- a/app/src/main/res/layout/activity_result.xml
+++ b/app/src/main/res/layout/activity_result.xml
@@ -36,7 +36,7 @@
         android:layout_height="wrap_content"
         android:text="@string/play_again_text"/>
 
-    <pl.droidsonroids.gif.GifImageView
+    <com.mozilla.hackathon.kiboko.widgets.AdjustableGifImageView
         android:id="@+id/result_image"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_screen_slide_page.xml
+++ b/app/src/main/res/layout/fragment_screen_slide_page.xml
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp" />
 
-        <pl.droidsonroids.gif.GifImageView
+        <com.mozilla.hackathon.kiboko.widgets.AdjustableGifImageView
             android:id="@+id/step_image"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -29,8 +29,7 @@
             android:src="@drawable/connectwifi9"
             android:layout_gravity="center_horizontal"
             android:gravity="center_horizontal"
-            android:background="@android:color/transparent"
-            />
+            android:background="@android:color/transparent" />
 
         <org.sufficientlysecure.htmltextview.HtmlTextView
             android:id="@+id/step_description"


### PR DESCRIPTION
Implements a compatibility wrapper around ```GifImageView``` that fixes the legacy behavior of the adjustViewBounds attribute on Android 17 and below (thus fixing squashed gifs).

Closes #185 