### PR TITLE
Use layout weight to scale welcome image based on available screen space

### DIFF
--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -11,7 +11,8 @@
         android:layout_marginBottom="15dp"
         android:layout_gravity="center_vertical|center_horizontal"
         android:layout_width="200dp"
-        android:layout_height="200dp" />
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
 
     <TextView
         android:layout_width="match_parent"


### PR DESCRIPTION
This is not a permanent fix. The permanent fix would be to create multiple layouts or define some sort of ruleset for scaling everything accordingly. This just uses layout weight to scale the welcome image based on available screen space, and doesn't effect any other UI components on the view.

A quick fix needs to be implemented in order to meet the release schedule, additionally this issue of poor scaling is wide spread throughout the app and requires additional attention. This will most likely be dealt with as work apart of a larger app redesign.

Related: #224 