### PR TITLE
Don't embed a scrollable container within another scrollable container, Resolves #239

### DIFF
--- a/app/src/main/res/layout/dashboard_layout.xml
+++ b/app/src/main/res/layout/dashboard_layout.xml
@@ -6,22 +6,9 @@
     tools:context="com.mozilla.hackathon.kiboko.activities.DashboardActivity"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <ScrollView
-        android:layout_width="match_parent"
-        android:fillViewport="true"
+    <fragment android:name="com.mozilla.hackathon.kiboko.fragments.TopicsFragment"
+        android:id="@+id/list"
         android:background="@color/colorPrimary"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:layout_height="match_parent">
-        <LinearLayout
-            android:orientation="vertical"
-            android:background="@color/colorPrimary"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <fragment android:name="com.mozilla.hackathon.kiboko.fragments.TopicsFragment"
-                android:id="@+id/list"
-                android:background="@color/colorPrimary"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-        </LinearLayout>
-    </ScrollView>
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </LinearLayout>


### PR DESCRIPTION
We currently embed a ```ListView``` within a ```ScrollView``` this is not optimal since both view containers have their own handlers for scrolling. Additionally, it's bad for performance as it forces the ListView to load all of it's contents, instead of functioning properly and efficiently.

See: https://developer.android.com/reference/android/widget/ScrollView.html

Closes: #239